### PR TITLE
Remove PHP cache (singleton) because can have problems on search when…

### DIFF
--- a/inc/commondbtm.class.php
+++ b/inc/commondbtm.class.php
@@ -3666,6 +3666,8 @@ class CommonDBTM extends CommonGLPI {
    public final function searchOptions() {
       static $options;
 
+      unset($options);
+
       if (!isset($options)) {
          $options = [];
 


### PR DESCRIPTION
… use multiple search or search field of 2 different items in same page
